### PR TITLE
调整加载流程;新增扩展包,支持多包加载

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,22 +2,27 @@ name-template: 'v$RESOLVED_VERSION 🌈'
 tag-template: 'v$RESOLVED_VERSION'
 categories:
   - title: ':sparkles: MOD更新'
-    labels: ['mod']
-  - title: ':sparkles: 新内容包'
-    labels: ['contents:new']
+    labels: [ 'mod','core' ]
+  - title: ':sparkles: 内容包'
+    labels: [ 'contents' ]
   - title: ':wrench: 洪水模式 Flood'
-    labels: ['contents:flood']
+    labels: [ 'contents:flood' ]
 autolabeler:
+  - label: 'core'
+    files:
+      - 'core/**'
   - label: 'contents:flood'
     files:
       - 'contents/flood/**'
-  - label: 'contents:new'
+  - label: 'contents'
     files:
-      - 'loaderMod/src/main/kotlin/cf/wayzer/contentsMod/Contents.kt'
+      - 'contents/src/**'
   - label: 'mod'
     files:
-      - 'loaderMod/**/!(Contents.kt)'
-change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
+      - 'loaderMod/**'
+change-template: |
+  - $TITLE @$AUTHOR (#$NUMBER)
+    > $BODY
 change-title-escapes: '\<*_&' # You can add # and @ to disable mentions, and add ` to disable code blocks.
 version-resolver:
   major:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,7 +20,9 @@ jobs:
           java-version: 16
 
       - name: build MOD
-        run: ./gradlew dist
+        run: |
+          export VERSION="beta-$GITHUB_RUN_NUMBER"
+          ./gradlew dist
       - name: Upload MOD JAR
         uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,9 @@ name: Build
 on:
   push:
     branches:
-      - '*'
+      - 'master'
   pull_request:
+    types: [ opened, reopened, synchronize ]
   workflow_dispatch:
 
 jobs:
@@ -26,6 +27,5 @@ jobs:
           path: loaderMod/build/dist/*
 
       - uses: release-drafter/release-drafter@v5
-        if: github.ref_name == 'master'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 group = "cf.wayzer.MindustryContents"
 version = System.getenv().getOrDefault("VERSION", "1.0-SNAPSHOT")
 
-allprojects {
+subprojects {
     apply { plugin("kotlin") }
     apply { plugin("maven-publish") }
     repositories {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,32 @@
 plugins {
     kotlin("jvm") version "1.6.10"
+    `maven-publish`
 }
 
 group = "cf.wayzer.MindustryContents"
 version = System.getenv().getOrDefault("VERSION", "1.0-SNAPSHOT")
+
+allprojects {
+    apply { plugin("kotlin") }
+    apply { plugin("maven-publish") }
+    repositories {
+        mavenCentral()
+        maven(url = "https://www.jitpack.io")
+    }
+    tasks.withType(JavaCompile::class) {
+        targetCompatibility = JavaVersion.VERSION_1_8.toString()
+        sourceCompatibility = JavaVersion.VERSION_16.toString()
+        options.compilerArgs.addAll(listOf("--release", "8"))
+    }
+    publishing {
+        publications {
+            create<MavenPublication>("maven") {
+                groupId = rootProject.group.toString()
+                artifactId = project.name
+                version = rootProject.version.toString()
+
+                from(components["kotlin"])
+            }
+        }
+    }
+}

--- a/contents/build.gradle.kts
+++ b/contents/build.gradle.kts
@@ -3,38 +3,29 @@ plugins {
     `maven-publish`
 }
 
+sourceSets {
+    main {
+        java.srcDir("src")
+    }
+}
+
+dependencies {
+    api(project(":core"))
+    compileOnly("com.github.Anuken.Mindustry:core:v135")
+    childProjects.values.forEach {
+        implementation(project(it.path))
+    }
+}
+
 subprojects {
-    apply { plugin("kotlin") }
-    apply { plugin("maven-publish") }
     sourceSets {
         main {
             java.srcDir("src")
         }
     }
-    repositories {
-        mavenCentral()
-        maven(url = "https://www.jitpack.io")
-    }
+
     dependencies {
+        api(project(":core"))
         compileOnly("com.github.Anuken.Mindustry:core:v135")
-    }
-
-    tasks.withType(JavaCompile::class) {
-        targetCompatibility = JavaVersion.VERSION_1_8.toString()
-        sourceCompatibility = JavaVersion.VERSION_16.toString()
-        options.compilerArgs.addAll(listOf("--release", "8"))
-    }
-
-    publishing {
-        publications {
-            create<MavenPublication>("maven") {
-                groupId = rootProject.group.toString()
-                artifactId = project.name
-                version = rootProject.version.toString()
-
-                from(components["kotlin"])
-                artifact(tasks.getByName("kotlinSourcesJar"))
-            }
-        }
     }
 }

--- a/contents/origin/README
+++ b/contents/origin/README
@@ -1,2 +1,0 @@
-使用游戏原版,无源代码
-No Source, using game original contents.

--- a/contents/src/Contents.kt
+++ b/contents/src/Contents.kt
@@ -1,7 +1,5 @@
-package cf.wayzer.contentsMod
-
-import cf.wayzer.contentsMod.MyContentLoader.Api.contentPacks
-import cf.wayzer.contentsMod.MyContentLoader.Api.overwriteContents
+import cf.wayzer.ContentsLoader.Api.contentPacks
+import cf.wayzer.ContentsLoader.Api.overwriteContents
 import mindustry.Vars
 import mindustry.content.flood.Blocks
 import mindustry.content.flood.Bullets
@@ -20,6 +18,7 @@ object Contents {
 
     fun exFactoryNotConsume() {
         Vars.content.blocks().filterIsInstance<GenericCrafter>().forEach {
+            it.canOverdrive = false
             it.consumes.remove(ConsumeType.item)
             it.consumes.remove(ConsumeType.liquid)
         }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,0 +1,14 @@
+plugins {
+    kotlin("jvm")
+}
+
+sourceSets {
+    main {
+        java.srcDir("src")
+    }
+}
+
+dependencies {
+    api(kotlin("stdlib"))
+    compileOnly("com.github.Anuken.Mindustry:core:v135")
+}

--- a/core/src/cf/wayzer/ContentsLoader.kt
+++ b/core/src/cf/wayzer/ContentsLoader.kt
@@ -1,4 +1,4 @@
-package cf.wayzer.contentsMod
+package cf.wayzer
 
 import arc.Events
 import arc.files.Fi
@@ -12,13 +12,13 @@ import mindustry.ctype.Content
 import mindustry.ctype.ContentList
 import mindustry.ctype.ContentType
 import mindustry.ctype.MappableContent
-import mindustry.game.EventType.ContentInitEvent
+import mindustry.game.EventType
 import mindustry.io.SaveVersion
 import mindustry.logic.LExecutor
 import mindustry.mod.Mods
 import kotlin.system.measureTimeMillis
 
-object MyContentLoader : ContentLoader() {
+object ContentsLoader : ContentLoader() {
     class ContentContainer(val type: ContentType?, val default: ContentList) {
         var content: ContentList = default
         val contentMap: Seq<Content> = if (type == null) Seq() else Vars.content.getBy<Content>(type).copy()
@@ -106,7 +106,7 @@ object MyContentLoader : ContentLoader() {
     private var temporaryMapper: Array<out Array<MappableContent>>? = null
     override fun setTemporaryMapper(temporaryMapper: Array<out Array<MappableContent>>?) {
         origin.setTemporaryMapper(temporaryMapper)
-        MyContentLoader.temporaryMapper = temporaryMapper
+        ContentsLoader.temporaryMapper = temporaryMapper
     }
 
     override fun <T : Content> getByID(type: ContentType, id: Int): T? {
@@ -123,9 +123,9 @@ object MyContentLoader : ContentLoader() {
         return contentMap[type]?.contentMap as Seq<T>? ?: origin.getBy(type)
     }
 
-    @Suppress("unused")
+    @Suppress("unused", "MemberVisibilityCanBePrivate")
     object Api {
-        val supportContents by MyContentLoader::contents
+        val supportContents by ContentsLoader::contents
         val contentPacks = mutableMapOf(
             "origin" to { contents.forEach { it.content = it.default } }
         )
@@ -134,7 +134,7 @@ object MyContentLoader : ContentLoader() {
             private set
 
         //platform impl
-        internal var logTimeCost: (tag: String, ms: Long) -> Unit = { _, _ -> }
+        var logTimeCost: (tag: String, ms: Long) -> Unit = { _, _ -> }
 
         private inline fun doMeasureTimeLog(tag: String, body: () -> Unit) {
             val time = measureTimeMillis(body)
@@ -188,7 +188,7 @@ object MyContentLoader : ContentLoader() {
                     contentPacks[pack]!!.invoke()
                 }
             }
-            Events.fire(ContentInitEvent())
+            Events.fire(EventType.ContentInitEvent())
             if (!Vars.headless) {
                 doMeasureTimeLog("ContentLoader.loadColors") {
                     loadColors()

--- a/loaderMod/build.gradle.kts
+++ b/loaderMod/build.gradle.kts
@@ -5,16 +5,10 @@ plugins {
     id("com.github.johnrengelman.shadow") version "7.1.2"
 }
 
-repositories {
-    mavenCentral()
-    maven(url = "https://www.jitpack.io")
-}
 dependencies {
     implementation(kotlin("stdlib"))
     compileOnly("com.github.Anuken.Mindustry:core:v135")
-    findProject(":contents")!!.childProjects.values.forEach {
-        implementation(project(it.path))
-    }
+    api(project(":contents"))
 }
 
 tasks.withType<ProcessResources> {
@@ -37,7 +31,7 @@ val jarAndroid = tasks.create("jarAndroid") {
     outputs.file(outFile)
     doLast {
         val sdkRoot = System.getenv("ANDROID_HOME") ?: System.getenv("ANDROID_SDK_ROOT")
-        if (sdkRoot == null || !File(sdkRoot).exists()) throw GradleException("No valid Android SDK found. Ensure that ANDROID_HOME is set to your Android SDK directory.");
+        if (sdkRoot == null || !File(sdkRoot).exists()) throw GradleException("No valid Android SDK found. Ensure that ANDROID_HOME is set to your Android SDK directory.")
 
         val d8Tool = File("$sdkRoot/build-tools/").listFiles()?.sortedDescending()
             ?.flatMap { dir -> (dir.listFiles().orEmpty()).filter { it.name.startsWith("d8") } }?.firstOrNull()

--- a/loaderMod/src/main/kotlin/cf/wayzer/contentsMod/Contents.kt
+++ b/loaderMod/src/main/kotlin/cf/wayzer/contentsMod/Contents.kt
@@ -1,34 +1,32 @@
 package cf.wayzer.contentsMod
 
-import arc.util.Log
+import cf.wayzer.contentsMod.MyContentLoader.Api.contentPacks
+import cf.wayzer.contentsMod.MyContentLoader.Api.overwriteContents
+import mindustry.Vars
 import mindustry.content.flood.Blocks
 import mindustry.content.flood.Bullets
 import mindustry.content.flood.UnitTypes
 import mindustry.ctype.ContentType
+import mindustry.world.blocks.production.GenericCrafter
+import mindustry.world.consumers.ConsumeType
 
 @Suppress("MemberVisibilityCanBePrivate")
 object Contents {
-    fun flood(): String {
-        ContentsLoader.overwriteContents(ContentType.block, Blocks())
-        ContentsLoader.overwriteContents(ContentType.bullet, Bullets())
-        ContentsLoader.overwriteContents(ContentType.unit, UnitTypes())
-        return "OK"
+    fun flood() {
+        overwriteContents(ContentType.block, Blocks())
+        overwriteContents(ContentType.bullet, Bullets())
+        overwriteContents(ContentType.unit, UnitTypes())
     }
 
-    fun origin(): String {
-        MyContentLoader.contents.forEach {
-            it.content = it.default
+    fun exFactoryNotConsume() {
+        Vars.content.blocks().filterIsInstance<GenericCrafter>().forEach {
+            it.consumes.remove(ConsumeType.item)
+            it.consumes.remove(ConsumeType.liquid)
         }
-        return "OK"
     }
 
-    fun loadType(type: String) = when (type.lowercase()) {
-        "flood" -> flood()
-        "origin" -> origin()
-        else -> {
-            Log.infoTag("ContentsLoader", "Unknown contents type $type")
-            origin()
-            "NOTFOUND"
-        }
+    fun register() {
+        contentPacks["flood"] = ::flood
+        contentPacks["EX-factoryNotConsume"] = ::exFactoryNotConsume
     }
 }

--- a/loaderMod/src/main/kotlin/cf/wayzer/contentsMod/ContentsLoader.kt
+++ b/loaderMod/src/main/kotlin/cf/wayzer/contentsMod/ContentsLoader.kt
@@ -2,22 +2,16 @@ package cf.wayzer.contentsMod
 
 import arc.func.Cons
 import arc.func.Prov
-import arc.struct.ObjectIntMap
 import arc.struct.ObjectMap
 import arc.struct.Seq
 import arc.util.Log
 import mindustry.Vars
-import mindustry.ctype.Content
-import mindustry.ctype.ContentList
-import mindustry.ctype.ContentType
 import mindustry.gen.Call
 import mindustry.gen.ClientPacketReliableCallPacket
-import mindustry.logic.LExecutor
 import mindustry.mod.Mod
 import mindustry.net.Net
 import mindustry.net.Packet
 import mindustry.net.Packets
-import kotlin.system.measureTimeMillis
 
 class MYClientPacketReliableCallPacket : ClientPacketReliableCallPacket() {
     override fun getPriority(): Int {
@@ -30,7 +24,14 @@ class MYClientPacketReliableCallPacket : ClientPacketReliableCallPacket() {
 class ContentsLoader : Mod() {
     override fun init() {
         Vars.content = MyContentLoader
+        MyContentLoader.Api.apply {
+            logTimeCost = { tag, time ->
+                Log.infoTag("ContentsLoader", "$tag costs ${time}ms")
+            }
+            Contents.register()
+        }
 
+        //hack: hook to beforeWorldLoad
         val clientListeners = Net::class.java.getDeclaredField("clientListeners").run {
             isAccessible = true
             @Suppress("UNCHECKED_CAST")
@@ -42,77 +43,23 @@ class ContentsLoader : Mod() {
             bak.get(it)
         }
 
+        //hack: modify ClientPacketReliableCallPacket priority
         val packetProvs = Net::class.java.getDeclaredField("packetProvs").run {
             isAccessible = true
             @Suppress("UNCHECKED_CAST")
             get(null) as Seq<Prov<out Packet>>
         }
         packetProvs[Net.getPacketId(ClientPacketReliableCallPacket()).toInt()] = ::MYClientPacketReliableCallPacket
-        Vars.netClient.addPacketHandler("ContentsLoader|load") {
-            Log.infoTag("ContentsLoader", "ToLoad $it")
-            Call.serverPacketReliable("ContentsLoader|load", loadType(it))
-        }
+
+        Vars.netClient.addPacketHandler("ContentsLoader|load", MyContentLoader.Api.toLoadPacks::add)
         Log.infoTag("ContentsLoader", "Finish Load Mod")
     }
 
-    @Suppress("unused", "MemberVisibilityCanBePrivate")
-    companion object API {
-        infix fun ContentList.eq(contentList: ContentList?): Boolean {
-            return javaClass == contentList?.javaClass
-        }
-
-        fun beforeWorldLoad() {
-            //fastPath
-            if (MyContentLoader.contents.all { it.content eq it.lastContent }) {
-                MyContentLoader.contents.forEach { it.content = it.default }
-                return
-            }
-            MyContentLoader.contents.forEach {
-                val time = measureTimeMillis { it.load() }
-                Log.infoTag("ContentsLoader", "Loaded ${it.lastContent!!::class.qualifiedName} costs ${time}ms")
-            }
-            val timeReloadConstants = measureTimeMillis {
-                Vars.constants.apply {
-                    javaClass.getDeclaredField("namesToIds")
-                        .apply { isAccessible = true }
-                        .set(this, ObjectIntMap<String>())
-                    javaClass.getDeclaredField("vars")
-                        .apply { isAccessible = true }
-                        .set(this, Seq<LExecutor.Var>(LExecutor.Var::class.java))
-                    init()
-                }
-            }
-            Log.infoTag("ContentsLoader", "Reload Vars.constants costs ${timeReloadConstants}ms")
-            if (!Vars.headless) {
-                val timeLoadColors = measureTimeMillis {
-                    MyContentLoader.loadColors()
-                }
-                Log.infoTag("ContentsLoader", "ContentLoader.loadColors costs ${timeLoadColors}ms")
-                val timeLoadIcon = measureTimeMillis {
-                    MyContentLoader.contents.forEach { it.contentMap.forEach(Content::loadIcon) }
-                }
-                Log.infoTag("ContentsLoader", "Content.loadIcon costs ${timeLoadIcon}ms")
-                val timeLoad = measureTimeMillis {
-                    MyContentLoader.contents.forEach { it.contentMap.forEach(Content::load) }
-                }
-                Log.infoTag("ContentsLoader", "Content.load costs ${timeLoad}ms")
-                val timeSchematics = measureTimeMillis {
-                    Vars.schematics.load()
-                }
-                Log.infoTag("ContentsLoader", "timeSchematics costs ${timeSchematics}ms")
-            }
-        }
-
-        fun maskChanged(type: ContentType) {
-            val c = MyContentLoader.contentMap[type] ?: throw IllegalArgumentException("Not Support Overwrite ContentType")
-            c.maskChanged()
-        }
-
-        fun overwriteContents(type: ContentType, list: ContentList) {
-            val c = MyContentLoader.contentMap[type] ?: throw IllegalArgumentException("Not Support Overwrite ContentType")
-            c.content = list
-        }
-
-        fun loadType(type: String) = Contents.loadType(type)
+    fun beforeWorldLoad() {
+        Log.infoTag("ContentsLoader", "ToLoad ${MyContentLoader.Api.toLoadPacks}")
+        val notFound = mutableListOf<String>()
+        MyContentLoader.Api.loadContent(notFound)
+        Call.serverPacketReliable("ContentsLoader|load", "LOADED: ${MyContentLoader.Api.lastLoadedPacks}")
+        Call.serverPacketReliable("ContentsLoader|load", "NOTFOUND: $notFound")
     }
 }

--- a/loaderMod/src/main/kotlin/cf/wayzer/contentsMod/Main.kt
+++ b/loaderMod/src/main/kotlin/cf/wayzer/contentsMod/Main.kt
@@ -1,10 +1,12 @@
 package cf.wayzer.contentsMod
 
+import Contents
 import arc.func.Cons
 import arc.func.Prov
 import arc.struct.ObjectMap
 import arc.struct.Seq
 import arc.util.Log
+import cf.wayzer.ContentsLoader
 import mindustry.Vars
 import mindustry.gen.Call
 import mindustry.gen.ClientPacketReliableCallPacket
@@ -20,11 +22,11 @@ class MYClientPacketReliableCallPacket : ClientPacketReliableCallPacket() {
     }
 }
 
-@Suppress("unused")
-class ContentsLoader : Mod() {
+@Suppress("unused", "MemberVisibilityCanBePrivate")
+class Main : Mod() {
     override fun init() {
-        Vars.content = MyContentLoader
-        MyContentLoader.Api.apply {
+        Vars.content = ContentsLoader
+        ContentsLoader.Api.apply {
             logTimeCost = { tag, time ->
                 Log.infoTag("ContentsLoader", "$tag costs ${time}ms")
             }
@@ -51,15 +53,15 @@ class ContentsLoader : Mod() {
         }
         packetProvs[Net.getPacketId(ClientPacketReliableCallPacket()).toInt()] = ::MYClientPacketReliableCallPacket
 
-        Vars.netClient.addPacketHandler("ContentsLoader|load", MyContentLoader.Api.toLoadPacks::add)
+        Vars.netClient.addPacketHandler("ContentsLoader|load", ContentsLoader.Api.toLoadPacks::add)
         Log.infoTag("ContentsLoader", "Finish Load Mod")
     }
 
     fun beforeWorldLoad() {
-        Log.infoTag("ContentsLoader", "ToLoad ${MyContentLoader.Api.toLoadPacks}")
+        Log.infoTag("ContentsLoader", "ToLoad ${ContentsLoader.Api.toLoadPacks}")
         val notFound = mutableListOf<String>()
-        MyContentLoader.Api.loadContent(notFound)
-        Call.serverPacketReliable("ContentsLoader|load", "LOADED: ${MyContentLoader.Api.lastLoadedPacks}")
+        ContentsLoader.Api.loadContent(notFound)
+        Call.serverPacketReliable("ContentsLoader|load", "LOADED: ${ContentsLoader.Api.lastLoadedPacks}")
         Call.serverPacketReliable("ContentsLoader|load", "NOTFOUND: $notFound")
     }
 }

--- a/loaderMod/src/main/resources/mod.json
+++ b/loaderMod/src/main/resources/mod.json
@@ -2,7 +2,7 @@
   "name": "ContentsLoader",
   "displayName": "内容包动态加载器",
   "author": "WayZer",
-  "main": "cf.wayzer.contentsMod.ContentsLoader",
+  "main": "cf.wayzer.contentsMod.Main",
   "description": "Dynamic load custom contents package account to server",
   "version": "@version@",
   "hidden": true,

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,6 @@
 rootProject.name = "MindustryContents"
-include("contents")
+include("core")
 include("contents:flood")
 include("contents:origin")
+include("contents")
 include("loaderMod")


### PR DESCRIPTION
* 整理代码,调整加载流程.
* 支持多包加载,新增扩展包
* 分离出core和contents模块，供其他项目引用
* (ci) 为测试版本添加版本号,例`beta-12345`
## 扩展资源包
以EX-开头,可修改内容属性.
在主包加载完成后 按字母序排序加载,
## 新增扩展包`EX-factoryNotConsume`
当前在Loader的Contents.kt文件内