### PR TITLE
4/4|4/5平衡 总结这段时间的游戏体验和反馈，调整属性

### DIFF
--- a/contents/flood/src/mindustry/content/flood/Blocks.java
+++ b/contents/flood/src/mindustry/content/flood/Blocks.java
@@ -1551,17 +1551,17 @@ public class Blocks implements ContentList{
         arc = new PowerTurret("arc"){{
             requirements(Category.turret, with(Items.copper, 50, Items.lead, 50));
             shootType = new LightningBulletType(){{
-                damage = 4;
-                lightningLength = 15;
+                damage = 25;
+                lightningLength = 5;
                 collidesAir = false;
                 ammoMultiplier = 1f;
             }};
-            reloadTime = 35f;
+            reloadTime = 60f;
             shootCone = 40f;
             rotateSpeed = 8f;
             powerUse = 3.3f;
             targetAir = false;
-            range = 90f;
+            range = 30f;
             shootEffect = Fx.lightningShoot;
             heatColor = Color.red;
             recoilAmount = 1f;
@@ -1616,7 +1616,7 @@ public class Blocks implements ContentList{
             );
 
             size = 2;
-            range = 230f;
+            range = 200f;
             reloadTime = 30f;
             restitution = 0.03f;
             ammoEjectBack = 3f;
@@ -1692,14 +1692,14 @@ public class Blocks implements ContentList{
                 Items.titanium, new ShrapnelBulletType(){{
                     length = brange;
                     damage = 200f;
-                    ammoMultiplier = 2f;
+                    ammoMultiplier = 1f;
                     width = 17f;
                     reloadMultiplier = 1.5f;
                 }},
                 Items.thorium, new ShrapnelBulletType(){{
                     length = brange;
                     damage = 500f;
-                    ammoMultiplier = 2f;
+                    ammoMultiplier = 1f;
                     toColor = Pal.thoriumPink;
                     shootEffect = smokeEffect = Fx.thoriumShoot;
                 }}
@@ -1764,29 +1764,17 @@ public class Blocks implements ContentList{
             requirements(Category.turret, with(Items.copper, 1000, Items.metaglass, 600, Items.surgeAlloy, 300, Items.plastanium, 200, Items.silicon, 600));
 
             ammo(
-                    Items.surgeAlloy, new LaserBulletType(){{
-                        length = 460f;
-                        damage = 560f;
-                        width = 75f;
-
-                        lifetime = 65f;
-
-                        lightningSpacing = 35f;
-                        lightningLength = 5;
-                        lightningDelay = 1.1f;
-                        lightningLengthRand = 15;
-                        lightningDamage = 50;
-                        lightningAngleRand = 40f;
-                        largeHit = true;
-                        lightColor = lightningColor = Pal.heal;
-
-                        shootEffect = Fx.greenLaserCharge;
-
-                        sideAngle = 15f;
-                        sideWidth = 0f;
-                        sideLength = 0f;
-                        colors = new Color[]{Pal.heal.cpy().a(0.4f), Pal.heal, Color.white};
-                    }}
+                    Items.surgeAlloy, new RailBulletType(){{
+                shootEffect = Fx.railShoot;
+                length = 500f;
+                updateEffectSeg = 60f;
+                pierceEffect = Fx.railHit;
+                updateEffect = Fx.railTrail;
+                hitEffect = Fx.massiveExplosion;
+                smokeEffect = Fx.shootBig2;
+                damage = 2000;
+                pierceDamageFactor = 0.33f;
+                }}
             );
 
             maxAmmo = 60;

--- a/contents/flood/src/mindustry/content/flood/Bullets.java
+++ b/contents/flood/src/mindustry/content/flood/Bullets.java
@@ -265,9 +265,9 @@ public class Bullets implements ContentList{
             hitEffect = Fx.blastExplosion;
             despawnEffect = Fx.blastExplosion;
             ammoMultiplier = 3f;
-            lightningDamage = 40;
+            lightningDamage = 60;
             lightning = 2;
-            lightningLength = 20;
+            lightningLength = 13;
         }};
 
         standardCopper = new BasicBulletType(2.5f, 35){{
@@ -292,7 +292,7 @@ public class Bullets implements ContentList{
             height = 13f;
             shootEffect = Fx.shootBig;
             smokeEffect = Fx.shootBigSmoke;
-            ammoMultiplier = 6;
+            ammoMultiplier = 5;
             pierceCap = 2;
             pierceBuilding = true;
             lifetime = 60f;
@@ -328,7 +328,7 @@ public class Bullets implements ContentList{
             hitSize = 4.8f;
             width = 15f;
             height = 21f;
-            pierceCap = 6;
+            pierceCap = 5;
             pierceBuilding = true;
             shootEffect = Fx.shootBig;
             ammoMultiplier = 4;
@@ -336,7 +336,7 @@ public class Bullets implements ContentList{
             knockback = 0.3f;
         }};
 
-        standardThoriumBig = new BasicBulletType(8f, 50, "bullet"){{
+        standardThoriumBig = new BasicBulletType(8f, 60, "bullet"){{
             hitSize = 5;
             width = 16f;
             height = 23f;
@@ -344,9 +344,10 @@ public class Bullets implements ContentList{
             pierceCap = 8;
             pierceBuilding = true;
             knockback = 0.7f;
+            ammoMultiplier = 3;
         }};
 
-        standardIncendiaryBig = new BasicBulletType(7f, 1, "bullet"){{
+        standardIncendiaryBig = new BasicBulletType(7f, 25, "bullet"){{
             width = 16f;
             height = 21f;
             frontColor = Pal.lightishOrange;
@@ -355,11 +356,11 @@ public class Bullets implements ContentList{
             hitEffect = new MultiEffect(Fx.hitBulletSmall, Fx.fireHit);
             shootEffect = Fx.shootBig;
             makeFire = true;
-            pierceCap = 16;
+            pierceCap = 5;
             pierceBuilding = true;
             knockback = 0.6f;
             ammoMultiplier = 3;
-            splashDamage = 15f;
+            splashDamage = 35f;
             splashDamageRadius = 24f;
         }};
 
@@ -414,7 +415,7 @@ public class Bullets implements ContentList{
         }};
 
         heavyWaterShot = new LiquidBulletType(Liquids.water){{
-            lifetime = 49f;
+            lifetime = 65f;
             speed = 4f;
             knockback = 1.7f;
             puddleSize = 8f;
@@ -426,7 +427,7 @@ public class Bullets implements ContentList{
         }};
 
         heavyCryoShot = new LiquidBulletType(Liquids.cryofluid){{
-            lifetime = 49f;
+            lifetime = 65f;
             speed = 4f;
             knockback = 1.3f;
             puddleSize = 8f;
@@ -438,7 +439,7 @@ public class Bullets implements ContentList{
         }};
 
         heavySlagShot = new LiquidBulletType(Liquids.slag){{
-            lifetime = 49f;
+            lifetime = 65f;
             speed = 4f;
             knockback = 1.3f;
             puddleSize = 16f;
@@ -450,7 +451,7 @@ public class Bullets implements ContentList{
         }};
 
         heavyOilShot = new LiquidBulletType(Liquids.oil){{
-            lifetime = 49f;
+            lifetime = 65f;
             speed = 4f;
             knockback = 1.3f;
             puddleSize = 16f;

--- a/contents/flood/src/mindustry/content/flood/UnitTypes.java
+++ b/contents/flood/src/mindustry/content/flood/UnitTypes.java
@@ -1491,7 +1491,7 @@ public class UnitTypes implements ContentList{
                 inaccuracy = 8f;
                 ejectEffect = Fx.casing1;
                 shootSound = Sounds.shoot;
-                bullet = Bullets.flakLead;
+                bullet = Bullets.fragGlassFrag;
             }});
 
             weapons.add(new Weapon("artillery-mount"){{
@@ -1652,7 +1652,7 @@ public class UnitTypes implements ContentList{
                 xRand = 8f;
                 shotDelay = 1f;
 
-                bullet = new MissileBulletType(4.2f, 42){{
+                bullet = new MissileBulletType(4.2f, 56){{
                     homingPower = 0.12f;
                     width = 8f;
                     height = 8f;
@@ -1690,7 +1690,7 @@ public class UnitTypes implements ContentList{
                 shots = 3;
                 shotDelay = 4f;
                 inaccuracy = 1f;
-                bullet = new BasicBulletType(7f, 57){{
+                bullet = new BasicBulletType(7f, 75){{
                     width = 13f;
                     height = 19f;
                     shootEffect = Fx.shootBig;
@@ -1908,7 +1908,7 @@ public class UnitTypes implements ContentList{
                 bullet = new BulletType(){{
                     shootEffect = Fx.sparkShoot;
                     hitEffect = Fx.pointHit;
-                    maxRange = 100f;
+                    maxRange = 150f;
                     damage = 17f;
                 }};
             }});
@@ -2073,7 +2073,7 @@ public class UnitTypes implements ContentList{
 
             buildSpeed = 3f;
 
-            abilities.add(new EnergyFieldAbility(50f, 65f, 180f){{
+            abilities.add(new EnergyFieldAbility(100f, 65f, 180f){{
                 statusDuration = 60f * 6f;
                 maxTargets = 25;
             }});
@@ -2089,7 +2089,7 @@ public class UnitTypes implements ContentList{
                     bullet = new BulletType(){{
                         shootEffect = Fx.sparkShoot;
                         hitEffect = Fx.pointHit;
-                        maxRange = 180f;
+                        maxRange = 240f;
                         damage = 24f;
                     }};
                 }});

--- a/contents/flood/src/mindustry/content/flood/UnitTypes.java
+++ b/contents/flood/src/mindustry/content/flood/UnitTypes.java
@@ -113,9 +113,9 @@ public class UnitTypes implements ContentList{
         }};
 
         scepter = new UnitType("scepter"){{
-            speed = 0.45f;
+            speed = 0.55f;
             hitSize = 22f;
-            rotateSpeed = 2.1f;
+            rotateSpeed = 2.3f;
             health = 9000;
             armor = 10f;
             mechFrontSway = 1f;
@@ -146,11 +146,11 @@ public class UnitTypes implements ContentList{
                     height = 20f;
                     lifetime = 25f;
                     shootEffect = Fx.shootBig;
-                    lightning = 4;
+                    lightning = 2;
                     lightningLength = 15;
                     lightningColor = Pal.surge;
                     //standard bullet damage is far too much for lightning
-                    lightningDamage = 40;
+                    lightningDamage = 80;
                 }};
             }},
 
@@ -175,9 +175,9 @@ public class UnitTypes implements ContentList{
         }};
 
         reign = new UnitType("reign"){{
-            speed = 0.45f;
+            speed = 0.5f;
             hitSize = 26f;
-            rotateSpeed = 1.65f;
+            rotateSpeed = 2f;
             health = 24000;
             armor = 14f;
             mechStepParticles = true;
@@ -199,7 +199,7 @@ public class UnitTypes implements ContentList{
                 ejectEffect = Fx.casing4;
                 shootSound = Sounds.bang;
 
-                bullet = new BasicBulletType(13f, 150){{
+                bullet = new BasicBulletType(13f, 175){{
                     pierce = true;
                     pierceCap = 20;
                     width = 14f;
@@ -1343,7 +1343,7 @@ public class UnitTypes implements ContentList{
             new Weapon(){{
                 x = y = 0f;
                 mirror = false;
-                reload = 900f;
+                reload = 600f;
                 minShootVelocity = 0.01f;
 
                 soundPitchMin = 1f;
@@ -1738,14 +1738,14 @@ public class UnitTypes implements ContentList{
 
                 bullet = new RailBulletType(){{
                     shootEffect = Fx.railShoot;
-                    length = 500;
+                    length = 500f;
                     updateEffectSeg = 60f;
                     pierceEffect = Fx.railHit;
                     updateEffect = Fx.railTrail;
                     hitEffect = Fx.massiveExplosion;
                     smokeEffect = Fx.shootBig2;
-                    damage = 4000;
-                    pierceDamageFactor = 0.9f;
+                    damage = 2000;
+                    pierceDamageFactor = 0.2f;
                 }};
             }});
         }};


### PR DESCRIPTION
炮台|子弹：
削弱齐射射程，
增加钍齐射和雷光的子弹消耗
幽灵：降低钍子弹消耗并加强伤害。硫幽灵穿透大幅降低，但增加本体与范围伤害
电弧：压缩射程，但增加伤害（可用于极短距离防御，需要测试）
修复部分炮台显示与实际射程不匹配的问题
合金炮：死星炮->弱化版海神炮（需要测试）

兵种：
增加陆战T4T5的移速与转向速度
雷霆射速提高50%（冷却时间：15s->10s)
优化海参伤害算法，提高穿透效果（需要测试）
加强T2|T4船辅裂解距离，加强T4船辅伤害 略加强T4船战 T2船战防空炮->对地（铅分裂子弹->玻璃气旋子弹）

性能优化：
大幅降低武器|兵种释放的电弧长度和数量，等比增加伤害